### PR TITLE
Fix PocketDev compatibility

### DIFF
--- a/template/compose.yml
+++ b/template/compose.yml
@@ -6,7 +6,6 @@ services:
     container_name: {{PROJECT_NAME}}-php
     restart: unless-stopped
     working_dir: /var/www
-    entrypoint: ["/entrypoint.sh"]
     ports:
       - "${VITE_PORT:-5173}:5173"
     volumes:

--- a/template/docker-laravel/local/php/Dockerfile
+++ b/template/docker-laravel/local/php/Dockerfile
@@ -37,8 +37,16 @@ WORKDIR /var/www
 # LOCAL DEVELOPMENT SECTION (development-specific configuration)
 # =============================================================================
 
+# Copy entrypoint script
+COPY docker-laravel/local/php/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 # Expose port 9000 for PHP-FPM
 EXPOSE 9000
 
-# Development uses volumes for hot-reloading, so no need to copy files
-# The entrypoint and application code are mounted via docker compose volumes
+# Switch to www-data for security
+USER www-data
+
+# Set entrypoint and default command
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["php-fpm"]

--- a/template/setup.sh
+++ b/template/setup.sh
@@ -116,7 +116,7 @@ check_prerequisites() {
         exit 1
     fi
     
-    if ! command_exists docker-compose; then
+    if ! command_exists docker-compose && ! docker compose version &>/dev/null; then
         print_error "Docker Compose is not installed. Please install Docker Compose first."
         exit 1
     fi


### PR DESCRIPTION
## Summary
- Fix docker-compose check to also accept `docker compose` (plugin form) - PocketDev has Docker Compose v5 as plugin, not standalone binary
- Add USER directive and bake entrypoint into local Dockerfile - enables compose:transform to generate Dockerfile.pocketdev with COPY instructions before USER directive
- Remove redundant entrypoint directive from compose.yml - now defined in Dockerfile; volume mount still allows hot-reload for local development

## Test plan
- [ ] Run setup.sh in PocketDev environment (should pass docker compose check)
- [ ] Run compose:transform on a project using this template
- [ ] Verify Dockerfile.pocketdev is generated with COPY before USER
- [ ] Run docker compose up -d and verify Laravel works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration for the PHP service initialization in local development environments.
  * Enhanced setup script compatibility to support both docker-compose v1 and docker compose v2 formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->