### PR TITLE
Fail with helpful error when .github folder is missing

### DIFF
--- a/template/setup.sh
+++ b/template/setup.sh
@@ -214,7 +214,17 @@ setup_laravel_docker() {
     
     # Copy and process GitHub Action workflow
     print_info "Setting up GitHub Action workflow..."
-    # .github directory is already at template root, no need to copy from docker/local
+    if [ ! -f ".github/workflows/docker-laravel.yml" ]; then
+        print_error "GitHub workflow not found (.github/workflows/docker-laravel.yml)"
+        print_info ""
+        print_info "This usually means the template was not installed correctly."
+        print_info "Please use the documented installation method:"
+        print_info ""
+        print_info "  curl -L https://github.com/tetrixdev/slim-docker-laravel-setup/archive/main.tar.gz | tar -xz --wildcards --strip-components=2 \"*/template/*\""
+        print_info ""
+        print_info "Note: 'cp -r template/*' does NOT copy hidden folders like .github"
+        exit 1
+    fi
     sed -i "s/{{PROJECT_NAME}}/$PROJECT_NAME/g; s/{{GITHUB_REPOSITORY_OWNER}}/$GITHUB_REPOSITORY_OWNER/g" .github/workflows/docker-laravel.yml
     print_success "GitHub Action workflow configured"
     


### PR DESCRIPTION
## Summary
- Setup script now fails with a clear error if `.github` folder is missing
- Error message explains the cause and shows the correct installation command

## Problem
When users manually copy template files using `cp -r template/*`, the hidden `.github` folder is not copied. The setup script then fails with an unhelpful error:
```
sed: can't read .github/workflows/docker-laravel.yml: No such file or directory
```

## Solution
Check if the file exists before attempting to process it. If missing, **fail with a helpful error message** that:
1. Explains what went wrong
2. Shows the correct installation command (`curl | tar`)
3. Notes that `cp -r template/*` doesn't copy hidden folders

## Why fail instead of warn?
The `.github` folder is a **required** part of the template containing CI/CD workflows. If it's missing:
- The user did not follow the documented installation method
- Continuing would result in a broken setup without CI/CD
- Failing with clear instructions guides users to fix their installation

## Test plan
- [ ] Run setup with `.github` folder present - should work as before
- [ ] Run setup without `.github` folder - should fail with helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)