### PR TITLE
feat: Add APP_KEY generation and dev URL parameter

### DIFF
--- a/template/setup.sh
+++ b/template/setup.sh
@@ -11,6 +11,7 @@ NC='\033[0m' # No Color
 # Command line parameter variables
 PARAM_PROJECT_NAME=""
 PARAM_PRODUCTION_URL=""
+PARAM_DEV_URL=""
 PARAM_GITHUB_OWNER=""
 PARAM_AUTO_DETECT=false
 
@@ -239,9 +240,20 @@ setup_laravel_docker() {
     # Update .env.example with project-specific values
     sed -i "s/{{PROJECT_NAME}}/$PROJECT_NAME/g" .env.example
     
-    # Create .env from .env.example with generated password
+    # Create .env from .env.example with generated password and app key
     cp .env.example .env
     sed -i "s/DB_PASSWORD=laravel/DB_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)/" .env
+
+    # Generate Laravel APP_KEY using openssl (survives container recreates in PocketDev)
+    APP_KEY="base64:$(openssl rand -base64 32)"
+    sed -i "s/APP_KEY=/APP_KEY=$APP_KEY/" .env
+    print_success "Application key generated"
+
+    # Set development APP_URL if provided
+    if [[ -n "$PARAM_DEV_URL" ]]; then
+        sed -i "s|APP_URL=http://localhost|APP_URL=$PARAM_DEV_URL|" .env
+        print_success "Development APP_URL set to $PARAM_DEV_URL"
+    fi
 
     # Process docker-laravel/production/.env.example
     sed -i "s/{{PROJECT_NAME}}/$PROJECT_NAME/g" docker-laravel/production/.env.example
@@ -299,6 +311,7 @@ usage() {
     echo "Options:"
     echo "  -n, --project-name NAME     Set project name (lowercase, no spaces)"
     echo "  -u, --production-url URL    Set production URL for .env.production"
+    echo "  -d, --dev-url URL           Set development APP_URL (for Vite HMR on external devices)"
     echo "  -o, --github-owner OWNER    Set GitHub repository owner manually"
     echo "  -a, --auto-detect-owner     Auto-accept detected GitHub owner (no prompt)"
     echo "  -h, --help                  Show this help message"
@@ -313,6 +326,9 @@ usage() {
     echo ""
     echo "  # Auto-detect GitHub owner without prompting"
     echo "  $0 -n myapp -u https://myapp.com -a"
+    echo ""
+    echo "  # Setup for external device access (e.g., mobile testing via Tailscale)"
+    echo "  $0 -n myapp -u https://myapp.com -d http://100.64.0.1 -a"
     echo ""
     echo "  # Mixed: provide some parameters, prompt for others"
     echo "  $0 -n myapp"
@@ -333,6 +349,15 @@ while [[ $# -gt 0 ]]; do
         -u|--production-url)
             if [[ -n "$2" && "$2" != -* ]]; then
                 PARAM_PRODUCTION_URL="$2"
+                shift 2
+            else
+                print_error "Option $1 requires a value"
+                exit 1
+            fi
+            ;;
+        -d|--dev-url)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                PARAM_DEV_URL="$2"
                 shift 2
             else
                 print_error "Option $1 requires a value"


### PR DESCRIPTION
## Summary
- Generate APP_KEY using openssl during setup (survives container recreates)
- Add `-d`/`--dev-url` parameter for setting development APP_URL
- Useful for external device access (mobile testing, Tailscale, etc.)

## Why This Change

In PocketDev, `compose:transform` injects files at Docker build time. When containers are recreated with `docker compose up -d --force-recreate`, the .env from the workspace is re-injected, losing any APP_KEY that was generated inside the container.

By generating the APP_KEY during `setup.sh` (in the workspace .env), it survives container recreates.

The `-d` parameter allows setting `APP_URL` for development, which is needed for Vite HMR when accessing from external devices (e.g., mobile testing via Tailscale IP).

## Test plan
- [ ] Run setup with `-d http://192.168.1.100` and verify APP_URL is set correctly
- [ ] Verify APP_KEY is generated and present in .env
- [ ] Verify APP_KEY survives `docker compose up -d --force-recreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added development URL parameter (-d/--dev-url) for configuring the application environment during setup.
  * Automatic APP_KEY generation during environment initialization.
  * Development URL automatically applied to APP_URL configuration.
  * Updated setup documentation and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->