### PR TITLE
feat: Add APP_KEY generation and dev URL parameter

### DIFF
--- a/template/setup.sh
+++ b/template/setup.sh
@@ -245,8 +245,12 @@ setup_laravel_docker() {
     sed -i "s/DB_PASSWORD=laravel/DB_PASSWORD=$(tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 32)/" .env
 
     # Generate Laravel APP_KEY using openssl (persists across container recreates)
+    if ! command_exists openssl; then
+        print_error "openssl is required to generate APP_KEY. Please install it and re-run setup."
+        exit 1
+    fi
     APP_KEY="base64:$(openssl rand -base64 32)"
-    sed -i "s/APP_KEY=/APP_KEY=$APP_KEY/" .env
+    sed -i "s|^APP_KEY=.*|APP_KEY=$APP_KEY|" .env
     print_success "Application key generated"
 
     # Set development APP_URL if provided (for Vite HMR on external devices)


### PR DESCRIPTION
## Summary
- Generate APP_KEY using openssl during setup (persists across container recreates)
- Add `-d`/`--dev-url` parameter for setting development APP_URL
- Useful for external device access (mobile testing, Tailscale, etc.)

## Why This Change

In PocketDev (and similar containerized environments), container recreates would cause the entrypoint to regenerate the APP_KEY each time, invalidating sessions and encrypted data.

By generating the APP_KEY during `setup.sh` (stored in the workspace .env), it persists across container recreates.

The `-d` parameter allows setting `APP_URL` for development, which is needed for Vite HMR when accessing from external devices.

## Changes

| File | Change |
|------|--------|
| `template/setup.sh` | Add `PARAM_DEV_URL` variable |
| `template/setup.sh` | Add `-d\|--dev-url` argument parsing |
| `template/setup.sh` | Generate APP_KEY with openssl after .env creation |
| `template/setup.sh` | Set APP_URL if dev URL provided |
| `template/setup.sh` | Update usage docs and examples |

## Test plan
- [ ] Run setup with `-d http://192.168.1.100` and verify APP_URL is set correctly
- [ ] Verify APP_KEY is generated and present in .env
- [ ] Verify APP_KEY survives `docker compose up -d --force-recreate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add command-line option to specify a custom development URL during setup.
  * Setup now generates and injects a Laravel application key and database password automatically.
  * When a development URL is provided, the app URL in the environment is updated accordingly.
  * Help/usage text updated with the new option and example; setup validates OpenSSL availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->