### PR TITLE
Add automatic trustProxies middleware configuration

### DIFF
--- a/template/setup.sh
+++ b/template/setup.sh
@@ -407,6 +407,27 @@ setup_laravel_docker() {
         print_success "Vite configured for Docker (using APP_URL for HMR)"
     fi
 
+    # Configure trustProxies middleware for reverse proxy support (Laravel 11+)
+    # This ensures Laravel recognizes HTTPS when behind proxy-nginx
+    local bootstrap_app="$LARAVEL_DIR/bootstrap/app.php"
+    if [ -f "$bootstrap_app" ]; then
+        if grep -q "trustProxies" "$bootstrap_app"; then
+            print_success "trustProxies already configured"
+        elif grep -q "withMiddleware" "$bootstrap_app"; then
+            print_info "Configuring trustProxies middleware..."
+            # Replace empty middleware closure with trustProxies
+            sed -i 's/->withMiddleware(function (Middleware $middleware): void {[[:space:]]*\/\/[[:space:]]*})/->withMiddleware(function (Middleware $middleware): void {\n        $middleware->trustProxies(at: '"'"'*'"'"');\n    })/g' "$bootstrap_app"
+            # Also handle case where it's on multiple lines
+            sed -i ':a;N;$!ba;s/->withMiddleware(function (Middleware $middleware): void {\n[[:space:]]*\/\/\n[[:space:]]*})/->withMiddleware(function (Middleware $middleware): void {\n        $middleware->trustProxies(at: '"'"'*'"'"');\n    })/g' "$bootstrap_app"
+            if grep -q "trustProxies" "$bootstrap_app"; then
+                print_success "trustProxies configured for reverse proxy support"
+            else
+                print_warning "Could not auto-configure trustProxies. Add manually to bootstrap/app.php:"
+                echo '        $middleware->trustProxies(at: '"'"'*'"'"');'
+            fi
+        fi
+    fi
+
     # Note: Laravel database configuration is handled via environment variables
     # Note: setup.sh is kept for future updates - run install.sh again to update infrastructure
 


### PR DESCRIPTION
## Summary
- Automatically configure `trustProxies` middleware for Laravel 11+ projects
- Fixes mixed content errors when deploying behind proxy-nginx

## What it does
1. Checks if `trustProxies` is already configured → skips if present
2. If not, modifies `www/bootstrap/app.php` to add `$middleware->trustProxies(at: '*');`
3. Shows warning with manual instructions if auto-config fails

## Why this is needed
When behind a reverse proxy, Laravel needs to trust `X-Forwarded-*` headers to correctly detect HTTPS. Without this, `asset()` and other URL helpers generate `http://` URLs even when the site is served over HTTPS.

## Test plan
- [x] Verified sed patterns work on standard Laravel 11 bootstrap/app.php
- [x] Verified idempotent (skips if already configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the setup script to include automatic configuration of reverse-proxy HTTPS middleware for Laravel 11+ applications. The installation process now intelligently detects existing middleware configurations, automatically applies required updates when necessary, properly handles both single and multi-line configuration format variations, and provides helpful guidance if manual adjustments are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->